### PR TITLE
Update Dockerfile and Jenkinsfile for Docker image build and push process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . /app
 
 RUN mvn package
 
-CMD ("java", "-jar", "target/OTP-1-1.0-SNAPSHOT.jar")
+CMD ("java", "-jar", "target/Shout-jar-with-dependencies.jar")

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY . /app
 
 RUN mvn package
 
-CMD ("java", "-jar", "target/Shout-jar-with-dependencies.jar")
+CMD ["java", "-jar", "target/Shout-jar-with-dependencies.jar"]


### PR DESCRIPTION
## Summary by Sourcery

Extend Jenkins pipeline to include checkout, Docker image build, and push to Docker Hub while configuring Docker environment settings, and tidy up the Dockerfile.

Enhancements:
- Add Docker CLI path and Docker Hub credentials variables to Jenkins environment
- Introduce checkout, Docker build, and Docker push stages in Jenkinsfile
- Remove default CMD declaration from Dockerfile