### PR TITLE
Add profile picture to posts

### DIFF
--- a/src/main/java/application/controller/AppController.java
+++ b/src/main/java/application/controller/AppController.java
@@ -37,6 +37,9 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 
+import static application.utils.ImageUtils.blobToImage;
+import static application.utils.ImageUtils.imageToBlob;
+
 public class AppController {
     PostService postService;
     AuthService authService;
@@ -243,33 +246,6 @@ public class AppController {
     public void closeModifyProfilePanel() {
         staticProfile.setVisible(true);
         modifyProfile.setVisible(false);
-    }
-
-    public Image blobToImage(byte[] byteArray) {
-        if (byteArray == null) {
-            System.out.println("blob is null");
-            return null;
-        }
-        InputStream iStream = new ByteArrayInputStream(byteArray);
-        return new Image(iStream);
-    }
-
-    public byte[] imageToBlob(Image image) {
-        if (image == null) {
-            System.out.println("image is null");
-            return null;
-        }
-        BufferedImage bImage = SwingFXUtils.fromFXImage(image, null);
-
-        ByteArrayOutputStream oStream = new ByteArrayOutputStream();
-        try {
-            ImageIO.write(bImage, "png", oStream);
-            byte[] imageBytes = oStream.toByteArray();
-            return imageBytes;
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
     }
 
     public void changeAvatar(ActionEvent actionEvent) {

--- a/src/main/java/application/controller/PostCellController.java
+++ b/src/main/java/application/controller/PostCellController.java
@@ -5,6 +5,7 @@ import application.model.entity.Post;
 import application.model.entity.User;
 import application.model.service.PostService;
 import application.model.service.UserService;
+import application.utils.ImageUtils;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -14,7 +15,9 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
+import javafx.scene.image.ImageView;
 
+import java.io.ByteArrayInputStream;
 import java.util.List;
 
 public class PostCellController {
@@ -26,6 +29,7 @@ public class PostCellController {
     @FXML private Button likeButton;
     @FXML private Button commentButton;
     @FXML private ListView<String> postComments;
+    @FXML private ImageView postProfilePicture;
 
     private PostService postService;
     private UserService userService;
@@ -40,6 +44,12 @@ public class PostCellController {
         authorRealName.setText(author != null ? author.getFirstName() + " " + author.getLastName() : "Unknown User");
         authorUsername.setText(author != null ? "@" + author.getUsername() : "Unknown User");
         contentLabel.setText(post.getContent());
+
+        byte[] profilePicture = (author != null ? author.getProfilePicture(): null);
+        if (profilePicture != null) {
+            postProfilePicture.setImage(ImageUtils.blobToImage(profilePicture));
+        }
+
     }
 
     public void setComments(List<Comment> comments) {

--- a/src/main/java/application/utils/ImageUtils.java
+++ b/src/main/java/application/utils/ImageUtils.java
@@ -1,0 +1,40 @@
+package application.utils;
+
+import javafx.embed.swing.SwingFXUtils;
+import javafx.scene.image.Image;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+public class ImageUtils {
+
+    public static Image blobToImage(byte[] byteArray) {
+        if (byteArray == null) {
+            System.out.println("blob is null");
+            return null;
+        }
+        InputStream iStream = new ByteArrayInputStream(byteArray);
+        return new Image(iStream);
+    }
+
+    public static byte[] imageToBlob(Image image) {
+        if (image == null) {
+            System.out.println("image is null");
+            return null;
+        }
+        BufferedImage bImage = SwingFXUtils.fromFXImage(image, null);
+
+        ByteArrayOutputStream oStream = new ByteArrayOutputStream();
+        try {
+            ImageIO.write(bImage, "png", oStream);
+            byte[] imageBytes = oStream.toByteArray();
+            return imageBytes;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/src/main/resources/fxml/post_cell.fxml
+++ b/src/main/resources/fxml/post_cell.fxml
@@ -1,29 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.shape.*?>
-<?import javafx.scene.image.*?>
-<?import javafx.scene.text.*?>
-<?import javafx.scene.effect.*?>
-<?import java.lang.*?>
 <?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.shape.*?>
+<?import javafx.scene.text.*?>
 
-<AnchorPane style="-fx-background-color: transparent;" stylesheets="@../css/style.css" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="application.controller.PostCellController">
+<AnchorPane style="-fx-background-color: transparent;" stylesheets="@../css/style.css" xmlns="http://javafx.com/javafx/17.0.12" xmlns:fx="http://javafx.com/fxml/1" fx:controller="application.controller.PostCellController">
    <children>
        <VBox fx:id="postCellVBox" spacing="15.0" styleClass="post" AnchorPane.bottomAnchor="10.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="10.0">
           <children>
             <HBox prefHeight="9.0" prefWidth="200.0">
                <children>
-                  <ImageView fitHeight="40.0" fitWidth="40.0" pickOnBounds="true" preserveRatio="true" styleClass="avatar">
+                  <ImageView fx:id="postProfilePicture" fitHeight="40.0" fitWidth="40.0" pickOnBounds="true" preserveRatio="true" styleClass="avatar">
                      <image>
                         <Image url="@../images/mock/empty-avatar.jpg" />
                      </image>


### PR DESCRIPTION
## Summary by Sourcery

Add support for displaying user profile pictures in post entries by introducing a reusable ImageUtils class for image conversion and updating the post cell UI and controller accordingly.

New Features:
- Display user profile pictures alongside posts in the post cell view

Enhancements:
- Extract blobToImage and imageToBlob methods into a centralized ImageUtils class
- Remove duplicated image conversion logic from AppController and import utilities statically

Chores:
- Update post_cell.fxml and PostCellController to include and populate an ImageView for author profile pictures